### PR TITLE
Perl shebang

### DIFF
--- a/src/ONCOCNV_getCounts.pl
+++ b/src/ONCOCNV_getCounts.pl
@@ -1,3 +1,4 @@
+#!/usr/bin/perl -w
 # This file is part of ONCOCNV - a tool to detect copy number alterations in amplicon sequencing data
 # Copyright (C) 2014 OncoDNA
 
@@ -15,7 +16,6 @@
 
 #Author: Valentina BOEVA
 
-#!/usr/bin/perl -w
 
 =pod
 

--- a/src/ONCOCNV_getCounts.pl
+++ b/src/ONCOCNV_getCounts.pl
@@ -16,7 +16,6 @@
 
 #Author: Valentina BOEVA
 
-
 =pod
 
 =head1 NAME

--- a/src/createTargetGC.pl
+++ b/src/createTargetGC.pl
@@ -16,7 +16,6 @@
 
 #Author: Valentina BOEVA
 
-
 =pod
 
 =head1 NAME

--- a/src/createTargetGC.pl
+++ b/src/createTargetGC.pl
@@ -1,3 +1,4 @@
+#!/usr/bin/perl -w
 # This file is part of ONCOCNV - a tool to detect copy number alterations in amplicon sequencing data
 # Copyright (C) 2016 OncoDNA
 
@@ -15,7 +16,6 @@
 
 #Author: Valentina BOEVA
 
-#!/usr/bin/perl -w
 
 =pod
 


### PR DESCRIPTION
The perl shebangs need to be moved to the top for easy execution.