### PR TITLE
Fix duplicate amplicon assignment at segment boundaries

### DIFF
--- a/src/processSamples.R
+++ b/src/processSamples.R
@@ -806,7 +806,7 @@ for (tumorID in (1:ntum)) {
 			segStart <- fit$output$start[seg]
 			segEnd <- fit$output$end[seg]
 
-			indLargeSeg <- which(data$chr==chr & data$start>=segStart  & data$start <= segEnd )
+			indLargeSeg <- which(data$chr==chr & data$start>=segStart  & data$end <= segEnd )
 			values <- ratio [indLargeSeg ]
       
       


### PR DESCRIPTION
Previously, amplicons with start == segEnd were included in both the current and the following segment. This skewed segMean values.

We had for example data point chr7:55210028-55210195, which belonged to two segments:
Segment 1: 55086942 – 55210028
Segment 2: 55210028 – 55269075
Thus, one point affected means of both segments, but only mean of Segment 2 was
shown in the final result for that data point.

The selection now uses the amplicon end coordinate instead of start, ensuring each amplicon is assigned to a single segment. This prevents overlapping assignments and yields correct copy number estimation.